### PR TITLE
Quick fixes in mysqlReScanForeignScan

### DIFF
--- a/mysql_fdw.c
+++ b/mysql_fdw.c
@@ -626,6 +626,9 @@ mysqlReScanForeignScan(ForeignScanState *node)
 {
 	MySQLFdwExecutionState *festate = (MySQLFdwExecutionState *) node->fdw_state;
 
-	mysql_data_seek(festate->result, 0);
+	if (festate->result)
+	{
+		mysql_data_seek(festate->result, 0);
+	}
 }
 


### PR DESCRIPTION
Not sure why the rescan was getting hit before the iterate function that would have initialised it, but without that test it was causing a segfault.
