### PR TITLE
Skip NULL "rows" values from EXPLAIN when performing query cost estimates.

### DIFF
--- a/mysql_fdw.c
+++ b/mysql_fdw.c
@@ -463,7 +463,7 @@ mysqlPlanForeignScan(Oid foreigntableid, PlannerInfo *root, RelOptInfo *baserel)
 	result = mysql_store_result(conn);
 
 	while ((row = mysql_fetch_row(result)))
-		rows += atof(row[8]);
+		if (row[8] != NULL) rows += atof(row[8]);
 
 	mysql_free_result(result);
 	mysql_close(conn);
@@ -731,7 +731,7 @@ mysqlGetForeignRelSize(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntablei
 	result = mysql_store_result(conn);
 
 	while ((row = mysql_fetch_row(result)))
-		rows += atof(row[8]);
+		if (row[8] != NULL) rows += atof(row[8]);
 
 	mysql_free_result(result);
 	mysql_close(conn);


### PR DESCRIPTION
This is required to avoid segmentation faults for UNION queries (as EXPLAIN ... UNION emits NULL "rows" values for 'UNION RESULT' selects). Please see the following example query:

```
mysql> explain (select host from user) union (select db from proc);
+----+--------------+------------+-------+---------------+---------+---------+------+------+-------------+
| id | select_type  | table      | type  | possible_keys | key     | key_len | ref  | rows | Extra       |
+----+--------------+------------+-------+---------------+---------+---------+------+------+-------------+
|  1 | PRIMARY      | user       | index | NULL          | PRIMARY | 228     | NULL |    7 | Using index |
|  2 | UNION        | proc       | index | NULL          | PRIMARY | 385     | NULL |    6 | Using index |
| NULL | UNION RESULT | <union1,2> | ALL   | NULL          | NULL    | NULL    | NULL | NULL |             |
+----+--------------+------------+-------+---------------+---------+---------+------+------+-------------+
3 rows in set (0.00 sec)
```

Prior to this commit, there were no NULL checks performed on "rows" before passing it into `atof()` (thus causing a segmentation fault).
