### PR TITLE
Fix support for fetching Binary BLOBs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Generated subdirectories
 /results/
+*.o
+*.so

--- a/mysql_query.h
+++ b/mysql_query.h
@@ -22,8 +22,8 @@
 #include "utils/rel.h"
 
 
-Datum mysql_convert_to_pg(Oid pgtyp, int pgtypmod, Datum daata, MySQLFdwExecState *festate);
+Datum mysql_convert_to_pg(Oid pgtyp, int pgtypmod, mysql_column *column);
 void mysql_bind_sql_var(Oid type, int attnum, Datum value, MYSQL_BIND *binds, bool *isnull);
-Datum mysql_bind_result(int attnum, Datum *value, bool *isnull, MYSQL_BIND *result_values);
+void mysql_bind_result(Oid pgtyp, int pgtypmod, MYSQL_FIELD *field, mysql_column *column);
 
 #endif /* MYSQL_QUERY_H */

--- a/option.c
+++ b/option.c
@@ -66,6 +66,7 @@ static struct MySQLFdwOption valid_options[] =
 	{ "password",       UserMappingRelationId },
 	{ "dbname",         ForeignTableRelationId },
 	{ "table_name",     ForeignTableRelationId },
+        { "max_blob_size",  ForeignTableRelationId },
 
 	/* Sentinel */
 	{ NULL,			InvalidOid }
@@ -192,6 +193,9 @@ mysql_get_options(Oid foreigntableid)
 
 		if (strcmp(def->defname, "table_name") == 0)
 			opt->svr_table = defGetString(def);
+
+		if (strcmp(def->defname, "max_blob_size") == 0)
+                  	opt->max_blob_size = strtoul(defGetString(def), NULL, 0);
 	}
 	/* Default values, if required */
 	if (!opt->svr_address)


### PR DESCRIPTION
This is a WIP patch that adds support for fetching binary BLOBs. Currently the FDW can fetch BLOBs only if they are null terminated c-strings.
- Fix formatting
- Finish adding support for specifying max blob size as a configuration option.
- Test handling of BLOB truncation.
- Merge mysql_column and MySQLColumn structs.
- Add comments
