### PR TITLE
Pattern matching improved

### DIFF
--- a/deparse.c
+++ b/deparse.c
@@ -901,7 +901,35 @@ mysql_deparse_operator_name(StringInfo buf, Form_pg_operator opform)
 	{
 		if (strcmp(opname, "~~") == 0)
 		{
-			appendStringInfoString(buf, "like");
+			appendStringInfoString(buf, "LIKE BINARY");
+		}
+		else if (strcmp(opname, "~~*") == 0)
+		{
+			appendStringInfoString(buf, "LIKE");
+		}
+		else if (strcmp(opname, "!~~") == 0)
+		{
+			appendStringInfoString(buf, "NOT LIKE BINARY");
+		}
+		else if (strcmp(opname, "!~~*") == 0)
+		{
+			appendStringInfoString(buf, "NOT LIKE");
+		}
+		else if (strcmp(opname, "~") == 0)
+		{
+			appendStringInfoString(buf, "REGEXP BINARY");
+		}
+		else if (strcmp(opname, "~*") == 0)
+		{
+			appendStringInfoString(buf, "REGEXP");
+		}
+		else if (strcmp(opname, "!~") == 0)
+		{
+			appendStringInfoString(buf, "NOT REGEXP BINARY");
+		}
+		else if (strcmp(opname, "!~*") == 0)
+		{
+			appendStringInfoString(buf, "NOT REGEXP");
 		}
 		else
 		{


### PR DESCRIPTION
Currently mysql_fdw only supports charecter matching mapping 
```
'~~' => 'like'
```
which means that Postgres case sensitive 'LIKE' and '~~' (to which 'LIKE' is converted by Postgres) 
are interpreted as case insesitive 'like' in MySQL which makes it difficult to create any Postgres frontend
application because operators are interpreted in different ways depending on underlying table.

Other operators (```ILIKE, ~~*, NOT LIKE, !~~, NOT ILIKE, !~~*, ~, ~*, !~, !~*```) are raising exceptions.

This pull request adds following operators mapping (from Postgres to MySQL):
```
~~ => LIKE BINARY
~~* (ILIKE) => LIKE 
!~~ (NOT LIKE) => NOT LIKE BINARY
!~~* (NOT ILIKE) => NOT LIKE  
~ => REGEXP BINARY
~* => REGEXP
!~ => NOT REGEXP BINARY
!~* => NOT REGEXP
```
It means that case sensitive Postgres operators are mapped to MySQL operators with BINARY, which are case sensitive. 

To make BINARY comparison working correctly if different characters sets are used, it is necessary to set correct charset. To only decent way to do it we found is to do for example
```
SET character_set_connection = latin1
```
in init command, see my next pull request.