### PR TITLE
Add init_command server option (used as MYSQL_INIT_COMMAND)

### DIFF
--- a/connection.c
+++ b/connection.c
@@ -94,7 +94,7 @@ mysql_get_connection(ForeignServer *server, UserMapping *user, mysql_opt *opt)
 	}
 	if (entry->conn == NULL)
 	{
-		entry->conn = mysql_connect(opt->svr_address, opt->svr_username, opt->svr_password, opt->svr_database, opt->svr_port);
+		entry->conn = mysql_connect(opt->svr_address, opt->svr_username, opt->svr_password, opt->svr_database, opt->svr_port, opt->svr_init_command);
 		elog(DEBUG3, "new mysql_fdw connection %p for server \"%s\"",
 			 entry->conn, server->servername);
 	}
@@ -156,7 +156,7 @@ mysql_rel_connection(MYSQL *conn)
 
 
 MYSQL*
-mysql_connect(char *svr_address, char *svr_username, char *svr_password, char *svr_database, int svr_port)
+mysql_connect(char *svr_address, char *svr_username, char *svr_password, char *svr_database, int svr_port, char *svr_init_command)
 {
 	MYSQL *conn = NULL;
 
@@ -169,6 +169,8 @@ mysql_connect(char *svr_address, char *svr_username, char *svr_password, char *s
 			));
 
 	_mysql_options(conn, MYSQL_SET_CHARSET_NAME, GetDatabaseEncodingName());
+    if ( svr_init_command != NULL )
+        _mysql_options(conn, MYSQL_INIT_COMMAND, svr_init_command);
 
 	if (!_mysql_real_connect(conn, svr_address, svr_username, svr_password, svr_database, svr_port, NULL, 0))
 		ereport(ERROR,

--- a/mysql_fdw.h
+++ b/mysql_fdw.h
@@ -52,6 +52,7 @@ typedef struct mysql_opt
 	char    *svr_password;		/* MySQL password */
 	char    *svr_database;		/* MySQL database name */
 	char    *svr_table;			/* MySQL table name */
+	char    *svr_init_command;	/* MySQL SQL statement to execute when connecting to the MySQL server. */
 } mysql_opt;
 
 /*
@@ -142,7 +143,7 @@ extern void mysql_deparse_analyze(StringInfo buf, char *dbname, char *relname);
 
 /* connection.c headers */
 MYSQL *mysql_get_connection(ForeignServer *server, UserMapping *user, mysql_opt *opt);
-MYSQL *mysql_connect(char *svr_address, char *svr_username, char *svr_password, char *svr_database, int svr_port);
+MYSQL *mysql_connect(char *svr_address, char *svr_username, char *svr_password, char *svr_database, int svr_port, char *svr_init_command);
 void  mysql_cleanup_connection(void);
 void mysql_rel_connection(MYSQL *conn);
 #endif /* POSTGRES_FDW_H */

--- a/option.c
+++ b/option.c
@@ -62,6 +62,7 @@ static struct MySQLFdwOption valid_options[] =
 	/* Connection options */
 	{ "host",           ForeignServerRelationId },
 	{ "port",           ForeignServerRelationId },
+	{ "init_command",   ForeignServerRelationId },
 	{ "username",       UserMappingRelationId },
 	{ "password",       UserMappingRelationId },
 	{ "dbname",         ForeignTableRelationId },
@@ -192,6 +193,9 @@ mysql_get_options(Oid foreigntableid)
 
 		if (strcmp(def->defname, "table_name") == 0)
 			opt->svr_table = defGetString(def);
+
+		if (strcmp(def->defname, "init_command") == 0)
+			opt->svr_init_command = defGetString(def);
 	}
 	/* Default values, if required */
 	if (!opt->svr_address)


### PR DESCRIPTION
This pull request adds init_command server option which is used as MYSQL_INIT_COMMAND and may be used as OPTION in CREATE SERVER statement. Example:
```
CREATE SERVER mysql_server
     FOREIGN DATA WRAPPER mysql_fdw
     OPTIONS ( init_command 'SET character_set_connection = latin1' );
```
