### PR TITLE
Add MariaDB client library compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,23 @@ MYSQL_CONFIG = mysql_config
 SHLIB_LINK := $(shell $(MYSQL_CONFIG) --libs)
 PG_CPPFLAGS := $(shell $(MYSQL_CONFIG) --include)
 
+# In Debian based distros, libmariadbclient-dev provides mariadbclient (rather than mysqlclient)
+ifneq ($(findstring mariadbclient,$(SHLIB_LINK)),)
+MYSQL_LIB = mariadbclient
+else
+MYSQL_LIB = mysqlclient
+endif
+
+UNAME = uname
+OS := $(shell $(UNAME))
+ifeq ($(OS), Darwin)
+DLSUFFIX = .dylib
+else
+DLSUFFIX = .so
+endif
+
+PG_CPPFLAGS += -D _MYSQL_LIBNAME=\"lib$(MYSQL_LIB)$(DLSUFFIX)\"
+
 ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/mysql_fdw.c
+++ b/mysql_fdw.c
@@ -134,12 +134,6 @@ static void mysqlEstimateCosts(PlannerInfo *root, RelOptInfo *baserel, Cost *sta
 
 static bool mysql_is_column_unique(Oid foreigntableid);
 
-#ifdef __APPLE__
-	#define _MYSQL_LIBNAME "libmysqlclient.dylib"
-#else
-	#define _MYSQL_LIBNAME "libmysqlclient.so"
-#endif
-
 void* mysql_dll_handle = NULL;
 static int wait_timeout = WAIT_TIMEOUT;
 static int interactive_timeout = INTERACTIVE_TIMEOUT;


### PR DESCRIPTION
The MariaDB client library on Debian-based distros provides `mariadbclient` (rather than `mysqlclient` like upstream). This patch is for providing valid arguments to `dlopen` in such environments.

The OS detection for library suffix determination was moved into the Makefile to avoid macro concatenation manoeuvres or nested `ifdef`s.