### PR TITLE
Fix leaked `hash_seq_search` scan

### DIFF
--- a/connection.c
+++ b/connection.c
@@ -149,6 +149,7 @@ mysql_rel_connection(MYSQL *conn)
 			elog(DEBUG3, "disconnecting mysql_fdw connection %p", entry->conn);
 			_mysql_close(entry->conn);
 			entry->conn = NULL;
+			hash_seq_term(&scan);
 			break;
 		}
 	}


### PR DESCRIPTION
Please see [this section](https://github.com/postgres/postgres/blob/master/src/backend/utils/hash/dynahash.c#L1237) of the PostgreSQL source code for details/rational.