### PR TITLE
Fix IMPORT FOREIGN SCHEMA issues with LIMIT/EXCLUDE

### DIFF
--- a/mysql_fdw.c
+++ b/mysql_fdw.c
@@ -1845,7 +1845,7 @@ mysqlImportForeignSchema(ImportForeignSchemaStmt *stmt, Oid serverOid)
             else
                 appendStringInfoString(&buf, ", ");
 
-            appendStringInfo(&buf, "%s", rv->relname);
+            appendStringInfo(&buf, "'%s'", rv->relname);
         }
         appendStringInfoChar(&buf, ')');
     }

--- a/mysql_fdw.c
+++ b/mysql_fdw.c
@@ -1819,7 +1819,7 @@ mysqlImportForeignSchema(ImportForeignSchemaStmt *stmt, Oid serverOid)
                      " JOIN"
                      "  information_schema.COLUMNS AS c"
                      " ON"
-                     "  t.TABLE_CATALOG = c.TABLE_CATALOG AND t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME"
+                     "  t.TABLE_CATALOG <=> c.TABLE_CATALOG AND t.TABLE_SCHEMA <=> c.TABLE_SCHEMA AND t.TABLE_NAME <=> c.TABLE_NAME"
                      " WHERE"
                      "  t.TABLE_SCHEMA = '%s'",
                      stmt->remote_schema);


### PR DESCRIPTION
The code for setting up the WHERE clause when using LIMIT/EXCLUDE in IMPORT FOREIGN SCHEMA does not wrap the table names in single quotes and as such causes an error in the WHERE clause for the foreign schema import. This patch wraps those table names in single quotes and resolves issue #83.