### PR TITLE
Change INFO on established mysql connection to DEBUG1

### DIFF
--- a/connection.c
+++ b/connection.c
@@ -213,7 +213,7 @@ mysql_connect(
 			));
 
 	// useful for verifying that the connection's secured
-	elog(INFO,
+	elog(DEBUG1,
 		"Successfully connected to MySQL database %s "
 		"at server %s with cipher %s "
 		"(server version: %s, protocol version: %d) ",


### PR DESCRIPTION
The user should not be bothered with it in normal operation because it
interferes with the output of queries executed. Moreover, INFO is
not possible to suppress using client_min_messages for having
reproducible regression test results (the message contains the mysql
server version). To debug, users can "SET client_min_messages = debug;"
to get the server connection information.

This unbreaks the regression tests for apt.postgresql.org/Debian.