### PR TITLE
Change to address asymmetric treatment of bytea <->binary values 

### DIFF
--- a/deparse.c
+++ b/deparse.c
@@ -758,6 +758,14 @@ mysql_deparse_const(Const *node, deparse_expr_cxt *context)
 		case INTERVALOID:
 			deparse_interval(buf, node->constvalue);
 			break;
+                case BYTEAOID:
+                        //the string for BYTEA always seems to be in the format "\\x##"
+                        //where # is a hex digit, Even if the value passed in is 'hi'::bytea
+                        //we will receive "\x6869". Making this assumption allows us to
+                        //quickly convert postgres escaped strings to mysql ones for comparison
+                        extval = OidOutputFunctionCall(typoutput, node->constvalue);
+                        appendStringInfo(buf, "X\'%s\'", extval + 2);
+                        break;			
 		default:
 			extval = OidOutputFunctionCall(typoutput, node->constvalue);
 			mysql_deparse_string_literal(buf, extval);

--- a/deparse.c
+++ b/deparse.c
@@ -759,10 +759,12 @@ mysql_deparse_const(Const *node, deparse_expr_cxt *context)
 			deparse_interval(buf, node->constvalue);
 			break;
                 case BYTEAOID:
-                        //the string for BYTEA always seems to be in the format "\\x##"
-                        //where # is a hex digit, Even if the value passed in is 'hi'::bytea
-                        //we will receive "\x6869". Making this assumption allows us to
-                        //quickly convert postgres escaped strings to mysql ones for comparison
+                        /*
+			 * the string for BYTEA always seems to be in the format "\\x##"
+                         * where # is a hex digit, Even if the value passed in is 'hi'::bytea
+                         * we will receive "\x6869". Making this assumption allows us to
+                         * quickly convert postgres escaped strings to mysql ones for comparison
+			 */
                         extval = OidOutputFunctionCall(typoutput, node->constvalue);
                         appendStringInfo(buf, "X\'%s\'", extval + 2);
                         break;			


### PR DESCRIPTION
varbinary and bytea values can be compared to escaped strings in mysql and postgres respectively, but with different formats (X'0102' vs '\x0101') up until now mysql_fdw had been sending the postgres string to mysql so equality comparisons would always fail. This change converts the postgres string to mysql's format before sending.

Hopefully this change meets your approval. Thanks for creating mysql_fdw :)