### PR TITLE
Fix Test failure with PG10: ERROR: unrecognized node type: 217 #147

### DIFF
--- a/mysql_fdw.c
+++ b/mysql_fdw.c
@@ -2112,7 +2112,11 @@ prepare_query_params(PlanState *node,
 	 * benefit, and it'd require postgres_fdw to know more than is desirable
 	 * about Param evaluation.)
 	 */
+#if PG_VERSION_NUM >= 100000
+	*param_exprs = (List *) ExecInitExprList(fdw_exprs, node);
+#else
 	*param_exprs = (List *) ExecInitExpr((Expr *) fdw_exprs, node);
+#endif
 
 	/* Allocate buffer for text form of query parameters. */
 	*param_values = (const char **) palloc0(numParams * sizeof(char *));


### PR DESCRIPTION
This is a patch that fix #147.
The same code as PostgreSQL FDW in PG10 except PostgreSQL FDW does not have version condition(PG_VERSION_NUM >= 100000).