### PR TITLE
bugfix: send whole row on UPDATE when there is a BEFORE trigger on table

### DIFF
--- a/expected/mysql_fdw.out
+++ b/expected/mysql_fdw.out
@@ -362,6 +362,23 @@ SELECT test_param_where2(1, 'One');
                  1
 (1 row)
 
+CREATE FUNCTION
+CREATE TRIGGER
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Update on public.employee
+   ->  Foreign Scan on public.employee
+         Output: emp_id, emp_name, 0, emp_id, employee.*
+         Local server startup cost: 10
+         Remote query: SELECT `emp_id`, `emp_name`, `emp_dept_id` FROM `testdb`.`employee` WHERE ((`emp_id` = 1)) FOR UPDATE
+(5 rows)
+
+UPDATE 1
+ emp_id |         emp_name         | emp_dept_id 
+--------+--------------------------+-------------
+      1 | emp - 1 trigger updated! |           0
+(1 row)
+
 DELETE FROM employee;
 DELETE FROM department;
 DELETE FROM empdata;

--- a/mysql_fdw.c
+++ b/mysql_fdw.c
@@ -1301,7 +1301,7 @@ mysqlPlanForeignModify(PlannerInfo *root,
 	if (!mysql_is_column_unique(foreignTableId))
 		elog(ERROR, "first column of remote table must be unique for INSERT/UPDATE/DELETE operation");
 
-	if (operation == CMD_INSERT)
+	if (operation == CMD_INSERT || (operation == CMD_UPDATE && rel->trigdesc && rel->trigdesc->trig_update_before_row))
 	{
 		TupleDesc tupdesc = RelationGetDescr(rel);
 		int attnum;

--- a/sql/mysql_fdw.sql
+++ b/sql/mysql_fdw.sql
@@ -82,6 +82,22 @@ create or replace function test_param_where2(integer, text) returns integer as '
 
 SELECT test_param_where2(1, 'One');
 
+CREATE FUNCTION trig_row_before_insupdate() RETURNS TRIGGER AS $$
+BEGIN
+	NEW.emp_name := NEW.emp_name || ' trigger updated!';
+		RETURN NEW;
+	END
+$$ language plpgsql;
+
+CREATE TRIGGER trig_row_before_insupd
+BEFORE INSERT OR UPDATE ON employee
+FOR EACH ROW EXECUTE PROCEDURE trig_row_before_insupdate();
+
+
+EXPLAIN (verbose, costs off)
+UPDATE employee set emp_dept_id = 0 where emp_id = 1;
+UPDATE employee set emp_dept_id = 0 where emp_id = 1;          -- all columns should be transmitted, emp_name should have trigger updated appended
+SELECT * from employee where emp_id = 1;
 DELETE FROM employee;
 DELETE FROM department;
 DELETE FROM empdata;


### PR DESCRIPTION
bug fix (and test) to send whole row on update when there's a before trigger. 
(weird had to manually create tables in mysql create foreign table does not create a table in mysql?) tested with pg11 and mysql 5.7