### PR TITLE
Add RTLD_DEEPBIND existence check

### DIFF
--- a/mysql_fdw.c
+++ b/mysql_fdw.c
@@ -207,9 +207,9 @@ static int interactive_timeout = INTERACTIVE_TIMEOUT;
 bool
 mysql_load_library(void)
 {
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if !defined(RTLD_DEEPBIND)
 	/*
-	 * Mac OS/BSD does not support RTLD_DEEPBIND, but it still
+	 * Some implementations do not support RTLD_DEEPBIND, but it still
 	 * works without the RTLD_DEEPBIND
 	 */
 	mysql_dll_handle = dlopen(_MYSQL_LIBNAME, RTLD_LAZY);


### PR DESCRIPTION
Closes #187.

Checks for `RTLD_DEEPBIND` directly, rather than checking for `__APPLE__` and `__FreeBSD__`

This was causing build failures in Alpine Linux, which uses `musl` instead of `glibc` and does not include `RTLD_DEEPBIND`:

https://git.musl-libc.org/cgit/musl/tree/include/dlfcn.h