### PR TITLE
Make IMPORT FOREIGN SCHEMA behave consistently with mixed-case table names

### DIFF
--- a/expected/select.out
+++ b/expected/select.out
@@ -944,6 +944,17 @@ SELECT * FROM enum_t1 ORDER BY id;
 (3 rows)
 
 DROP FOREIGN TABLE enum_t1;
+-- Issue #202 - correct handling of mixed-case table names.
+IMPORT FOREIGN SCHEMA mysql_fdw_regress LIMIT TO ("mixedCaseTable") FROM SERVER mysql_svr INTO public;
+SELECT * FROM "mixedCaseTable" ORDER BY id;
+ id | mixedCaseColumn 
+----+-----------------
+  1 | small
+  2 | medium
+  3 | large
+(3 rows)
+
+DROP FOREIGN TABLE "mixedCaseTable";
 -- Cleanup
 DROP TABLE l_test_tbl1;
 DROP TABLE l_test_tbl2;

--- a/mysql_fdw.c
+++ b/mysql_fdw.c
@@ -1699,7 +1699,7 @@ mysqlImportForeignSchema(ImportForeignSchemaStmt *stmt, Oid serverOid)
 	{
 		bool		first_item = true;
 
-		appendStringInfoString(&buf, " AND t.TABLE_NAME ");
+		appendStringInfoString(&buf, " AND t.TABLE_NAME COLLATE UTF8_GENERAL_CI ");
 		if (stmt->list_type == FDW_IMPORT_SCHEMA_EXCEPT)
 			appendStringInfoString(&buf, "NOT ");
 		appendStringInfoString(&buf, "IN (");

--- a/mysql_init.sh
+++ b/mysql_init.sh
@@ -29,6 +29,7 @@ mysql -h $MYSQL_HOST -u $MYSQL_USER_NAME -P $MYSQL_PORT -D mysql_fdw_regress -e 
 mysql -h $MYSQL_HOST -u $MYSQL_USER_NAME -P $MYSQL_PORT -D mysql_fdw_regress1 -e "DROP TABLE IF EXISTS student;"
 mysql -h $MYSQL_HOST -u $MYSQL_USER_NAME -P $MYSQL_PORT -D mysql_fdw_regress1 -e "DROP TABLE IF EXISTS numbers;"
 mysql -h $MYSQL_HOST -u $MYSQL_USER_NAME -P $MYSQL_PORT -D mysql_fdw_regress -e "DROP TABLE IF EXISTS enum_t1;"
+mysql -h $MYSQL_HOST -u $MYSQL_USER_NAME -P $MYSQL_PORT -D mysql_fdw_regress -e "DROP TABLE IF EXISTS mixedCaseTable;"
 
 mysql -h $MYSQL_HOST -u $MYSQL_USER_NAME -P $MYSQL_PORT -D mysql_fdw_regress -e "CREATE TABLE mysql_test(a int primary key, b int);"
 mysql -h $MYSQL_HOST -u $MYSQL_USER_NAME -P $MYSQL_PORT -D mysql_fdw_regress -e "INSERT INTO mysql_test(a,b) VALUES (1,1);"
@@ -40,3 +41,5 @@ mysql -h $MYSQL_HOST -u $MYSQL_USER_NAME -P $MYSQL_PORT -D mysql_fdw_regress1 -e
 mysql -h $MYSQL_HOST -u $MYSQL_USER_NAME -P $MYSQL_PORT -D mysql_fdw_regress1 -e "CREATE TABLE numbers (a int, b varchar(255));"
 mysql -h $MYSQL_HOST -u $MYSQL_USER_NAME -P $MYSQL_PORT -D mysql_fdw_regress -e "CREATE TABLE enum_t1 (id int PRIMARY KEY, size ENUM('small', 'medium', 'large'));"
 mysql -h $MYSQL_HOST -u $MYSQL_USER_NAME -P $MYSQL_PORT -D mysql_fdw_regress -e "INSERT INTO enum_t1 VALUES (1, 'small'),(2, 'medium'),(3, 'medium');"
+mysql -h $MYSQL_HOST -u $MYSQL_USER_NAME -P $MYSQL_PORT -D mysql_fdw_regress -e "CREATE TABLE mixedCaseTable (id int PRIMARY KEY, mixedCaseColumn text);"
+mysql -h $MYSQL_HOST -u $MYSQL_USER_NAME -P $MYSQL_PORT -D mysql_fdw_regress -e "INSERT INTO mixedCaseTable VALUES (1, 'small'),(2, 'medium'),(3, 'large');"

--- a/sql/select.sql
+++ b/sql/select.sql
@@ -237,6 +237,11 @@ IMPORT FOREIGN SCHEMA mysql_fdw_regress LIMIT TO (enum_t1) FROM SERVER mysql_svr
 SELECT * FROM enum_t1 ORDER BY id;
 DROP FOREIGN TABLE enum_t1;
 
+-- Issue #202 - correct handling of mixed-case table names.
+IMPORT FOREIGN SCHEMA mysql_fdw_regress LIMIT TO ("mixedCaseTable") FROM SERVER mysql_svr INTO public;
+SELECT * FROM "mixedCaseTable" ORDER BY id;
+DROP FOREIGN TABLE "mixedCaseTable";
+
 -- Cleanup
 DROP TABLE l_test_tbl1;
 DROP TABLE l_test_tbl2;


### PR DESCRIPTION
The case of the table names returned by `information_schema` queries depends on MySQL's `lower_case_table_names` setting: on systems where the value is non-zero the table name will be forced to lowercase. Importing tables with mixed-case names requires different SQL depending on the MySQL server's settings as explained in #202.

This PR fixes the issue by [forcing a suitable collation](https://dev.mysql.com/doc/refman/5.7/en/charset-collation-information-schema.html) so that the `information_schema` query is case insensitive when matching table names and preserves case in the results.

Fixes #202.
