### PR TITLE
Add placeholder BeginForeignInsert function to prevent crash

### DIFF
--- a/mysql_fdw.c
+++ b/mysql_fdw.c
@@ -188,6 +188,12 @@ static List *mysqlImportForeignSchema(ImportForeignSchemaStmt *stmt,
 									  Oid serverOid);
 #endif
 
+#if PG_VERSION_NUM >= 110000
+static void mysqlBeginForeignInsert(ModifyTableState *mtstate,
+									   ResultRelInfo *resultRelInfo);
+#endif
+
+
 /*
  * Helper functions
  */
@@ -416,6 +422,12 @@ mysql_fdw_handler(PG_FUNCTION_ARGS)
 	/* Support functions for IMPORT FOREIGN SCHEMA */
 #if PG_VERSION_NUM >= 90500
 	fdwroutine->ImportForeignSchema = mysqlImportForeignSchema;
+#endif
+
+#if PG_VERSION_NUM >= 110000
+	/* Partition routing and/or COPY from */
+	fdwroutine->BeginForeignInsert = mysqlBeginForeignInsert;
+	fdwroutine->EndForeignInsert = NULL;
 #endif
 
 	PG_RETURN_POINTER(fdwroutine);
@@ -1870,6 +1882,25 @@ mysqlImportForeignSchema(ImportForeignSchemaStmt *stmt, Oid serverOid)
 	mysql_release_connection(conn);
 
 	return commands;
+}
+#endif
+
+#if PG_VERSION_NUM >= 110000
+/*
+ * mysqlBeginForeignInsert
+ *
+ * Prepare for an insert operation triggered by partition routing
+ * or COPY FROM.
+ * This is not yet supported, so raise an error.
+ */
+
+static void
+mysqlBeginForeignInsert(ModifyTableState *mtstate,
+						ResultRelInfo *resultRelInfo)
+{
+	ereport(ERROR,
+			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
+			 errmsg("COPY and foreign partition routing not supported")));
 }
 #endif
 


### PR DESCRIPTION
Beginning with PostgreSQL 11, inserts resulting from a COPY FROM operation or partition tuple routing need to be handled, even if only an error message is raised indicating the functionality is not available.

Without this, a server crash will occur, e.g.:

```
postgres=# \d my_instest 
                       Foreign table "public.my_instest"
 Column |         Type          | Collation | Nullable | Default | FDW options 
--------+-----------------------+-----------+----------+---------+-------------
 id     | integer               |           |          |         | 
 val    | character varying(30) |           |          |         | 
Server: mysql_server
FDW options: (dbname 'test', table_name 'instest')

postgres=# COPY my_instest FROM STDIN WITH (format 'csv');
Enter data to be copied followed by a newline.
End with a backslash and a period on a line by itself, or an EOF signal.
>> 1,foo
2,bar
\.>> >> 
server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.

```

This patch results in an error being raised:

```
postgres=# COPY my_instest FROM STDIN WITH (format 'csv');
Enter data to be copied followed by a newline.
End with a backslash and a period on a line by itself, or an EOF signal.
>> 1,foo
2,bar
\.>> >> 
ERROR:  COPY and foreign partition routing not supported
```