### PR TITLE
Fix regression tests for different fetch size on 32-bit platforms

### DIFF
--- a/expected/server_options_1.out
+++ b/expected/server_options_1.out
@@ -1,0 +1,274 @@
+\set MYSQL_HOST			`echo \'"$MYSQL_HOST"\'`
+\set MYSQL_PORT			`echo \'"$MYSQL_PORT"\'`
+\set MYSQL_USER_NAME	`echo \'"$MYSQL_USER_NAME"\'`
+\set MYSQL_PASS			`echo \'"$MYSQL_PWD"\'`
+-- Before running this file User must create database mysql_fdw_regress on
+-- MySQL with all permission for MYSQL_USER_NAME user with MYSQL_PWD password
+-- and ran mysql_init.sh file to create tables.
+\c contrib_regression
+CREATE EXTENSION IF NOT EXISTS mysql_fdw;
+CREATE SERVER mysql_svr FOREIGN DATA WRAPPER mysql_fdw
+  OPTIONS (host :MYSQL_HOST, port :MYSQL_PORT);
+CREATE USER MAPPING FOR public SERVER mysql_svr
+  OPTIONS (username :MYSQL_USER_NAME, password :MYSQL_PASS);
+-- Validate extension, server and mapping details
+CREATE OR REPLACE FUNCTION show_details(host TEXT, port TEXT, uid TEXT, pwd TEXT) RETURNS int AS $$
+DECLARE
+  ext TEXT;
+  srv TEXT;
+  sopts TEXT;
+  uopts TEXT;
+BEGIN
+  SELECT e.fdwname, srvname, array_to_string(s.srvoptions, ','), array_to_string(u.umoptions, ',')
+    INTO ext, srv, sopts, uopts
+    FROM pg_foreign_data_wrapper e LEFT JOIN pg_foreign_server s ON e.oid = s.srvfdw LEFT JOIN pg_user_mapping u ON s.oid = u.umserver
+    WHERE e.fdwname = 'mysql_fdw'
+    ORDER BY 1, 2, 3, 4;
+
+  raise notice 'Extension            : %', ext;
+  raise notice 'Server               : %', srv;
+
+  IF strpos(sopts, host) <> 0 AND strpos(sopts, port) <> 0 THEN
+    raise notice 'Server_Options       : matched';
+  END IF;
+
+  IF strpos(uopts, uid) <> 0 AND strpos(uopts, pwd) <> 0 THEN
+    raise notice 'User_Mapping_Options : matched';
+  END IF;
+
+  return 1;
+END;
+$$ language plpgsql;
+SELECT show_details(:MYSQL_HOST, :MYSQL_PORT, :MYSQL_USER_NAME, :MYSQL_PASS);
+NOTICE:  Extension            : mysql_fdw
+NOTICE:  Server               : mysql_svr
+NOTICE:  Server_Options       : matched
+NOTICE:  User_Mapping_Options : matched
+ show_details 
+--------------
+            1
+(1 row)
+
+-- Create foreign table and perform basic SQL operations
+CREATE FOREIGN TABLE f_mysql_test(a int, b int)
+  SERVER mysql_svr OPTIONS (dbname 'mysql_fdw_regress', table_name 'mysql_test');
+SELECT a, b FROM f_mysql_test ORDER BY 1, 2;
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+INSERT INTO f_mysql_test (a, b) VALUES (2, 2);
+SELECT a, b FROM f_mysql_test ORDER BY 1, 2;
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+(2 rows)
+
+UPDATE f_mysql_test SET b = 3 WHERE a = 2;
+SELECT a, b FROM f_mysql_test ORDER BY 1, 2;
+ a | b 
+---+---
+ 1 | 1
+ 2 | 3
+(2 rows)
+
+DELETE FROM f_mysql_test WHERE a = 2;
+SELECT a, b FROM f_mysql_test ORDER BY 1, 2;
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+DROP FOREIGN TABLE f_mysql_test;
+DROP USER MAPPING FOR public SERVER mysql_svr;
+DROP SERVER mysql_svr;
+-- Server with init_command.
+CREATE SERVER mysql_svr1 FOREIGN DATA WRAPPER mysql_fdw
+  OPTIONS (host :MYSQL_HOST, port :MYSQL_PORT, init_command 'create table init_command_check(a int)');
+CREATE USER MAPPING FOR public SERVER mysql_svr1
+  OPTIONS (username :MYSQL_USER_NAME, password :MYSQL_PASS);
+CREATE FOREIGN TABLE f_mysql_test (a int, b int)
+  SERVER mysql_svr1 OPTIONS (dbname 'mysql_fdw_regress', table_name 'mysql_test');
+-- This will create init_command_check table in mysql_fdw_regress database.
+SELECT a, b FROM f_mysql_test ORDER BY 1, 2;
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+-- init_command_check table created mysql_fdw_regress database can be verified
+-- by creating corresponding foreign table here.
+CREATE FOREIGN TABLE f_init_command_check(a int)
+  SERVER mysql_svr1 OPTIONS (dbname 'mysql_fdw_regress', table_name 'init_command_check');
+SELECT a FROM f_init_command_check ORDER BY 1;
+ a 
+---
+(0 rows)
+
+-- Changing init_command to drop init_command_check table from
+-- mysql_fdw_regress database
+ALTER SERVER mysql_svr1 OPTIONS (SET init_command 'drop table init_command_check');
+SELECT a, b FROM f_mysql_test;
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+DROP FOREIGN TABLE f_init_command_check;
+DROP FOREIGN TABLE f_mysql_test;
+DROP USER MAPPING FOR public SERVER mysql_svr1;
+DROP SERVER mysql_svr1;
+-- Server with use_remote_estimate.
+CREATE SERVER mysql_svr1 FOREIGN DATA WRAPPER mysql_fdw
+  OPTIONS(host :MYSQL_HOST, port :MYSQL_PORT, use_remote_estimate 'TRUE');
+CREATE USER MAPPING FOR public SERVER mysql_svr1
+  OPTIONS(username :MYSQL_USER_NAME, password :MYSQL_PASS);
+CREATE FOREIGN TABLE f_mysql_test(a int, b int)
+  SERVER mysql_svr1 OPTIONS(dbname 'mysql_fdw_regress', table_name 'mysql_test');
+-- Below explain will return actual rows from MySQL, but keeping costs off
+-- here for consistent regression result.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT a FROM f_mysql_test WHERE a < 2 ORDER BY 1;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Sort
+   Output: a
+   Sort Key: f_mysql_test.a
+   ->  Foreign Scan on public.f_mysql_test
+         Output: a
+         Remote query: SELECT `a` FROM `mysql_fdw_regress`.`mysql_test` WHERE ((`a` < 2))
+(6 rows)
+
+DROP FOREIGN TABLE f_mysql_test;
+DROP USER MAPPING FOR public SERVER mysql_svr1;
+DROP SERVER mysql_svr1;
+-- Create server with secure_auth.
+CREATE SERVER mysql_svr1 FOREIGN DATA WRAPPER mysql_fdw
+  OPTIONS(host :MYSQL_HOST, port :MYSQL_PORT, secure_auth 'FALSE');
+CREATE USER MAPPING FOR public SERVER mysql_svr1
+  OPTIONS(username :MYSQL_USER_NAME, password :MYSQL_PASS);
+CREATE FOREIGN TABLE f_mysql_test(a int, b int)
+  SERVER mysql_svr1 OPTIONS(dbname 'mysql_fdw_regress', table_name 'mysql_test');
+-- Below should fail with Warning of secure_auth is false.
+SELECT a, b FROM f_mysql_test ORDER BY 1, 2;
+WARNING:  MySQL secure authentication is off
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+DROP FOREIGN TABLE f_mysql_test;
+DROP USER MAPPING FOR public SERVER mysql_svr1;
+DROP SERVER mysql_svr1;
+-- FDW-335: Support for fetch_size option at server level and table level.
+CREATE SERVER fetch101 FOREIGN DATA WRAPPER mysql_fdw
+  OPTIONS( fetch_size '101' );
+SELECT count(*)
+  FROM pg_foreign_server
+  WHERE srvname = 'fetch101'
+  AND srvoptions @> array['fetch_size=101'];
+ count 
+-------
+     1
+(1 row)
+
+ALTER SERVER fetch101 OPTIONS( SET fetch_size '202' );
+SELECT count(*)
+  FROM pg_foreign_server
+  WHERE srvname = 'fetch101'
+  AND srvoptions @> array['fetch_size=101'];
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*)
+  FROM pg_foreign_server
+  WHERE srvname = 'fetch101'
+  AND srvoptions @> array['fetch_size=202'];
+ count 
+-------
+     1
+(1 row)
+
+CREATE FOREIGN TABLE table30000 ( x int ) SERVER fetch101
+  OPTIONS ( fetch_size '30000' );
+SELECT COUNT(*)
+  FROM pg_foreign_table
+  WHERE ftrelid = 'table30000'::regclass
+  AND ftoptions @> array['fetch_size=30000'];
+ count 
+-------
+     1
+(1 row)
+
+ALTER FOREIGN TABLE table30000 OPTIONS ( SET fetch_size '60000');
+SELECT COUNT(*)
+  FROM pg_foreign_table
+  WHERE ftrelid = 'table30000'::regclass
+  AND ftoptions @> array['fetch_size=30000'];
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*)
+  FROM pg_foreign_table
+  WHERE ftrelid = 'table30000'::regclass
+  AND ftoptions @> array['fetch_size=60000'];
+ count 
+-------
+     1
+(1 row)
+
+-- Make sure that changing the table level fetch-size value did not change the
+-- server level value.
+SELECT count(*)
+  FROM pg_foreign_server
+  WHERE srvname = 'fetch101'
+  AND srvoptions @> array['fetch_size=202'];
+ count 
+-------
+     1
+(1 row)
+
+-- Negative test cases for fetch_size option, should error out.
+ALTER FOREIGN TABLE table30000 OPTIONS ( SET fetch_size '-60000');
+ERROR:  "fetch_size" requires an integer value between 1 to 4294967295
+ALTER FOREIGN TABLE table30000 OPTIONS ( SET fetch_size '123abc');
+ERROR:  "fetch_size" requires an integer value between 1 to 4294967295
+ALTER FOREIGN TABLE table30000 OPTIONS ( SET fetch_size '999999999999999999999');
+ERROR:  "fetch_size" requires an integer value between 1 to 4294967295
+-- Cleanup fetch_size test objects.
+DROP FOREIGN TABLE  table30000;
+DROP SERVER fetch101;
+-- FDW-350: Support for reconnect option at server level.
+CREATE SERVER reconnect1 FOREIGN DATA WRAPPER mysql_fdw
+  OPTIONS( reconnect 'true' );
+SELECT count(*)
+  FROM pg_foreign_server
+  WHERE srvname = 'reconnect1'
+  AND srvoptions @> array['reconnect=true'];
+ count 
+-------
+     1
+(1 row)
+
+ALTER SERVER reconnect1 OPTIONS( SET reconnect 'false' );
+SELECT count(*)
+  FROM pg_foreign_server
+  WHERE srvname = 'reconnect1'
+  AND srvoptions @> array['reconnect=false'];
+ count 
+-------
+     1
+(1 row)
+
+-- Negative test case for reconnect option, should error out.
+ALTER SERVER reconnect1 OPTIONS ( SET reconnect 'abc1' );
+ERROR:  reconnect requires a Boolean value
+-- Cleanup reconnect option test objects.
+DROP SERVER reconnect1;
+-- Cleanup
+DROP EXTENSION mysql_fdw;


### PR DESCRIPTION
Net diff between server_options.out and server_options_1.out is:

--- expected/server_options.out	2021-10-01 16:19:20.320972814 +0200
+++ expected/server_options_1.out	2021-10-01 16:22:04.428838428 +0200
@@ -235,11 +235,11 @@

 -- Negative test cases for fetch_size option, should error out.
 ALTER FOREIGN TABLE table30000 OPTIONS ( SET fetch_size '-60000');
-ERROR:  "fetch_size" requires an integer value between 1 to 18446744073709551615
+ERROR:  "fetch_size" requires an integer value between 1 to 4294967295
 ALTER FOREIGN TABLE table30000 OPTIONS ( SET fetch_size '123abc');
-ERROR:  "fetch_size" requires an integer value between 1 to 18446744073709551615
+ERROR:  "fetch_size" requires an integer value between 1 to 4294967295
 ALTER FOREIGN TABLE table30000 OPTIONS ( SET fetch_size '999999999999999999999');
-ERROR:  "fetch_size" requires an integer value between 1 to 18446744073709551615
+ERROR:  "fetch_size" requires an integer value between 1 to 4294967295
 -- Cleanup fetch_size test objects.
 DROP FOREIGN TABLE  table30000;
 DROP SERVER fetch101;