### PR TITLE
Catch output variation for recent MariaDB server changes

### DIFF
--- a/expected/connection_validation.out
+++ b/expected/connection_validation.out
@@ -34,7 +34,7 @@ $$
 BEGIN
   SELECT * FROM f_mysql_test ORDER BY 1, 2;
   EXCEPTION WHEN others THEN
-	IF SQLERRM LIKE 'failed to connect to MySQL: Unknown MySQL server host ''localhos'' (%)' THEN
+	IF SQLERRM LIKE 'failed to connect to MySQL: Unknown %server host ''localhos'' (%)' THEN
 	  RAISE NOTICE 'failed to connect to MySQL: Unknown MySQL server host ''localhos''';
     ELSE
 	  RAISE NOTICE '%', SQLERRM;

--- a/sql/connection_validation.sql
+++ b/sql/connection_validation.sql
@@ -34,7 +34,7 @@ $$
 BEGIN
   SELECT * FROM f_mysql_test ORDER BY 1, 2;
   EXCEPTION WHEN others THEN
-	IF SQLERRM LIKE 'failed to connect to MySQL: Unknown MySQL server host ''localhos'' (%)' THEN
+	IF SQLERRM LIKE 'failed to connect to MySQL: Unknown %server host ''localhos'' (%)' THEN
 	  RAISE NOTICE 'failed to connect to MySQL: Unknown MySQL server host ''localhos''';
     ELSE
 	  RAISE NOTICE '%', SQLERRM;


### PR DESCRIPTION
MariaDB 10.5 prints "Unknown server host" instead of "Unknown MySQL server host".

We are already normalizing the error message in tests, accept that form as well.

Regression diff observed was:
-NOTICE:  failed to connect to MySQL: Unknown MySQL server host 'localhos'
+NOTICE:  failed to connect to MySQL: Unknown server host 'localhos' (-2)