### PR TITLE
Use hardcoded values only if environment variables are not set

### DIFF
--- a/mysql_init.sh
+++ b/mysql_init.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-export MYSQL_PWD="edb"
-export MYSQL_HOST="localhost"
-export MYSQL_PORT="3306"
-export MYSQL_USER_NAME="edb"
+export MYSQL_PWD="${MYSQL_PWD:-edb}"
+export MYSQL_HOST="${MYSQL_HOST:-localhost}"
+export MYSQL_PORT="${MYSQL_PORT:-3306}"
+export MYSQL_USER_NAME="${MYSQL_USER_NAME:-edb}"
 
 # Below commands must be run first time to create mysql_fdw_regress and mysql_fdw_regress1 databases
 # used in regression tests with edb user and edb password.

--- a/mysql_init.sh
+++ b/mysql_init.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-export MYSQL_PWD="${MYSQL_PWD:-edb}"
-export MYSQL_HOST="${MYSQL_HOST:-localhost}"
-export MYSQL_PORT="${MYSQL_PORT:-3306}"
-export MYSQL_USER_NAME="${MYSQL_USER_NAME:-edb}"
+export MYSQL_PWD="${MYSQL_PWD:=edb}"
+export MYSQL_HOST="${MYSQL_HOST:=localhost}"
+export MYSQL_PORT="${MYSQL_PORT:=3306}"
+export MYSQL_USER_NAME="${MYSQL_USER_NAME:=edb}"
 
 # Below commands must be run first time to create mysql_fdw_regress and mysql_fdw_regress1 databases
 # used in regression tests with edb user and edb password.


### PR DESCRIPTION
Prioritize Environment Variables before using the hard-coded defaults in mysql_init.sh 

At times the test PG setup is non-local, however, despite setting up the PG variables, the mysql_init.sh script currently only uses hard-coded values.