### PR TITLE
Allow non-superusers to run server-options test

### DIFF
--- a/expected/server_options.out
+++ b/expected/server_options.out
@@ -19,9 +19,9 @@ DECLARE
   sopts TEXT;
   uopts TEXT;
 BEGIN
-  SELECT e.fdwname, srvname, array_to_string(s.srvoptions, ','), array_to_string(u.umoptions, ',')
+  SELECT e.fdwname, s.srvname, array_to_string(s.srvoptions, ','), array_to_string(u.umoptions, ',')
     INTO ext, srv, sopts, uopts
-    FROM pg_foreign_data_wrapper e LEFT JOIN pg_foreign_server s ON e.oid = s.srvfdw LEFT JOIN pg_user_mapping u ON s.oid = u.umserver
+    FROM pg_foreign_data_wrapper e LEFT JOIN pg_foreign_server s ON e.oid = s.srvfdw LEFT JOIN pg_user_mappings u ON s.oid = u.srvid
     WHERE e.fdwname = 'mysql_fdw'
     ORDER BY 1, 2, 3, 4;
 

--- a/sql/server_options.sql
+++ b/sql/server_options.sql
@@ -22,9 +22,9 @@ DECLARE
   sopts TEXT;
   uopts TEXT;
 BEGIN
-  SELECT e.fdwname, srvname, array_to_string(s.srvoptions, ','), array_to_string(u.umoptions, ',')
+  SELECT e.fdwname, s.srvname, array_to_string(s.srvoptions, ','), array_to_string(u.umoptions, ',')
     INTO ext, srv, sopts, uopts
-    FROM pg_foreign_data_wrapper e LEFT JOIN pg_foreign_server s ON e.oid = s.srvfdw LEFT JOIN pg_user_mapping u ON s.oid = u.umserver
+    FROM pg_foreign_data_wrapper e LEFT JOIN pg_foreign_server s ON e.oid = s.srvfdw LEFT JOIN pg_user_mappings u ON s.oid = u.srvid
     WHERE e.fdwname = 'mysql_fdw'
     ORDER BY 1, 2, 3, 4;
 


### PR DESCRIPTION
Allow non-superusers to run server-options regression test.

The server_options test uses pg_user_mapping catalog that is
only available to postgres superusers. Thus means non-superusers
fail this regression test by design.

Since most of that data is already available in pg_user_mappings
view, using that instead additionally allows non-superusers to
pass the test.