### PR TITLE
Support RETURNING on mariadb > 10.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /results/
 *.o
 *.so
+.idea
+*.bc

--- a/deparse.c
+++ b/deparse.c
@@ -446,12 +446,47 @@ mysql_deparse_from_expr(List *quals, deparse_expr_cxt *context)
 	}
 }
 
+/**
+ * convertReturningList()
+ *
+ * Generate RETURNING clause of a INSERT/UPDATE/DELETE ... RETURNING
+ * statement.
+ */
+static void
+convertReturningList(StringInfo buf, PlannerInfo *root, Index rtindex,
+                     Relation rel, bool doNothing, List *returningList)
+{
+    bool first;
+    ListCell   *lc;
+
+    elog(ERROR, "entering function %s", __func__);
+
+    /* Insert column names into the local query's RETURNING list */
+    if (returningList) {
+        elog(ERROR, "entering function %s with returningList", __func__);
+        appendStringInfoString(buf, " RETURNING ");
+        first = true;
+        elog(ERROR, "query: %s", (char*)buf);
+        foreach(lc, returningList)
+        {
+            int attnum = lfirst_int(lc);
+
+            if (!first)
+                appendStringInfoString(buf, ", ");
+            first = false;
+
+            elog(ERROR, "query: %s", (char*)buf);
+            mysql_deparse_column_ref(buf, rtindex, attnum, root, true);
+        }
+    }
+}
+
 /*
  * Deparse remote INSERT statement
  */
 void
 mysql_deparse_insert(StringInfo buf, PlannerInfo *root, Index rtindex,
-					 Relation rel, List *targetAttrs, bool doNothing)
+					 Relation rel, List *targetAttrs, bool doNothing, List *returningList)
 {
 	ListCell   *lc;
 #if PG_VERSION_NUM >= 140000
@@ -505,6 +540,10 @@ mysql_deparse_insert(StringInfo buf, PlannerInfo *root, Index rtindex,
 	}
 	else
 		appendStringInfoString(buf, " DEFAULT VALUES");
+    convertReturningList(buf, root, rtindex, rel,
+                         doNothing, returningList);
+    elog(ERROR, "query: %s", (char*)buf);
+
 }
 
 void

--- a/mysql_fdw.h
+++ b/mysql_fdw.h
@@ -306,7 +306,7 @@ extern mysql_opt *mysql_get_options(Oid foreigntableid, bool is_foreigntable);
 /* depare.c headers */
 extern void mysql_deparse_insert(StringInfo buf, PlannerInfo *root,
 								 Index rtindex, Relation rel,
-								 List *targetAttrs, bool doNothing);
+								 List *targetAttrs, bool doNothing, List *returningList);
 extern void mysql_deparse_update(StringInfo buf, PlannerInfo *root,
 								 Index rtindex, Relation rel,
 								 List *targetAttrs, char *attname);
@@ -324,6 +324,8 @@ extern void mysql_deparse_select_stmt_for_rel(StringInfo buf,
 											  bool has_limit,
 											  List **retrieved_attrs,
 											  List **params_list);
+//extern static void convertReturningList(StringInfo buf, PlannerInfo *root, Index rtindex,
+//                                        Relation rel, bool doNothing, List *returningList);
 extern const char *mysql_get_jointype_name(JoinType jointype);
 extern bool mysql_is_foreign_param(PlannerInfo *root, RelOptInfo *baserel,
 								   Expr *expr);


### PR DESCRIPTION
Hi all,

MariaDB > 10.5 does support RETURNING now.

https://mariadb.com/kb/en/insertreturning/

I'd like to add this feature to mysql_fdw - but without knowing the fdw sources / postgres internals it is hard to handle.

This is Work in Progress - maybe someone has already done this - also working on it ? 

Currently i do get a cache lookup error on the columns translate - i think i am using it not correct.

