### PR TITLE
Support parameter passing to foreign server

### DIFF
--- a/deparse.c
+++ b/deparse.c
@@ -1764,6 +1764,8 @@ foreign_expr_walker(Node *node, foreign_glob_cxt *glob_cxt,
 				else if (inner_cxt.state == FDW_COLLATE_SAFE &&
 						 collation == inner_cxt.collation)
 					state = FDW_COLLATE_SAFE;
+                                else if (collation == DEFAULT_COLLATION_OID)
+                                        state = FDW_COLLATE_NONE;
 				else
 					state = FDW_COLLATE_UNSAFE;
 			}


### PR DESCRIPTION
This PR adds support for forwarding on parameters of prepared statements to MySQL, and adds a cache for same to support statement reuse. 

For example, given:
```
PREPARE stmt2(varchar, varchar) AS SELECT "ycsb_key", "field1" from test.usertable16 WHERE "ycsb_key" = $1 AND "field1" = $2;
execute stmt2('user6578719', 'URxagQKtjthTPuimdkHxYDnjILIhMWcGVLYncvagEcJWgqtpQZeenCPJlywchyuhGLdDWTmqmibMoNEfDQqtgWoqcCOQBfTUPthu');
```

The `execute` call now sends:
```
SELECT `ycsb_key`, `field1` FROM `test`.`usertable16` WHERE ((`ycsb_key` = ?)) AND ((`field1` = ?))
```
Instead of a query using constant value. Sending on the parameters allows MySQL to cache & re-use the plan.

**NOTE** the Postgres setting `plan_cache_mode` should be set to `force_generic_plan` for this patch to have impact. Otherwise, Postgres may create a plan that replaces the parameters before handing the plan to the FDW, breaking the forwarding of the parameters to the foreign server.

In testing with `go-ycsb` I have seen a 5x improvement in throughput and improved latency. This is largely due to the nature of the benchmark (lots of the same queries with parameters), but without this patch the same benchmark performs very poorly as the mysql side needs to rebuild the plan on each statement.