### PR TITLE
Fix alias error in mysql_deparse_from_expr_for_rel

### DIFF
--- a/deparse.c
+++ b/deparse.c
@@ -2122,7 +2122,7 @@ mysql_deparse_from_expr_for_rel(StringInfo buf, PlannerInfo *root,
 		 * join.
 		 */
 		if (use_alias)
-			appendStringInfo(buf, " %s%d", REL_ALIAS_PREFIX,
+			appendStringInfo(buf, " %s%u", REL_ALIAS_PREFIX,
 							 foreignrel->relid);
 
 		table_close(rel, NoLock);


### PR DESCRIPTION
The relation OID/Index is unsigned int in PostgreSQL. When OID is greater than or equal to 2^31, it is negative when converted to int.

Therefore, the generated alias contains a '-' character, but the name is not allowed to have a "-" in MySQL, otherwise a syntax error will be reported, just like this:

```
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-2147483643' at line 1
```